### PR TITLE
Update network.py, resolve unsupported attributes issues

### DIFF
--- a/fpgaconvnet/hls/generate/network.py
+++ b/fpgaconvnet/hls/generate/network.py
@@ -41,8 +41,18 @@ class GenerateNetwork:
         # set up parser
         print("FIXME: use HLS backend in Parser")
         self.parser = Parser(backend="chisel", batch_size=self.partitions.partition[0].batch_size) # FIXME specify quant mode
+        # modify network to be supported by onnx
+        model = onnx.load(model_path)
+        nodes = model.graph.node
+        for node in nodes:
+            attrs = node.attribute
+            for attr in attrs[:]:
+                if attr.name in ['weight_width','data_width','acc_width', 'block_floating_point']:
+                    attrs.remove(attr)
+        new_model_path = model_path.replace('.onnx','_new.onnx')
+        onnx.save(model, new_model_path)
         # load network (parser onnx model)
-        self.net = self.parser.onnx_to_fpgaconvnet(model_path)
+        self.net = self.parser.onnx_to_fpgaconvnet(new_model_path)
         # load the existing partition information into the net object
         self.net = self.parser.prototxt_to_fpgaconvnet(self.net,partition_path)
 
@@ -183,5 +193,4 @@ class GenerateNetwork:
         # TODO: add multi-threading for partitions
         for i in range(len(self.partitions_generator)):
             self.generate_partition(i)
-
 


### PR DESCRIPTION
Update network.py, resolve unsupported attributes issues. The onnxruntime inferencesession doesn't support `weight_width`, `data_width`, `acc_width`, and `block_floating_point`, hence a new onnx file _new.onnx is created to get rid of these four attributes. 